### PR TITLE
Fix TIFF writer bug

### DIFF
--- a/com.github._4lex4.ScanTailor-Advanced.yaml
+++ b/com.github._4lex4.ScanTailor-Advanced.yaml
@@ -44,6 +44,8 @@ modules:
         path: com.github._4lex4.ScanTailor-Advanced.metainfo.xml.in
       - type: patch
         path: scantailor-qt5.15.patch
+      - type: patch
+        path: scantailor-tiffsave-fix.patch
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/scantailor-tiffsave-fix.patch
+++ b/scantailor-tiffsave-fix.patch
@@ -1,0 +1,26 @@
+From f6ae1624bf2cb55d1bd10a14d6215c2414633e32 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hubert=20Figui=C3=A8re?= <hub@figuiere.net>
+Date: Tue, 5 Jan 2021 15:23:48 -0500
+Subject: [PATCH] Issue #164 - Fix TIFF saving when JPEG and posterized
+
+---
+ src/core/TiffWriter.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/core/TiffWriter.cpp b/src/core/TiffWriter.cpp
+index 0713e05ad..f84be661c 100644
+--- a/src/core/TiffWriter.cpp
++++ b/src/core/TiffWriter.cpp
+@@ -222,8 +222,10 @@ bool TiffWriter::writeBitonalOrIndexed8Image(const TiffHandle& tif, const QImage
+   }
+ 
+   if (image.format() == QImage::Format_Indexed8) {
+-    TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION,
+-                 uint16(ApplicationSettings::getInstance().getTiffColorCompression()));
++    uint16 compress = (photometric == PHOTOMETRIC_PALETTE) ?
++                      COMPRESSION_LZW :
++                      uint16(ApplicationSettings::getInstance().getTiffColorCompression());
++    TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION, compress);
+   } else {
+     TIFFSetField(tif.handle(), TIFFTAG_COMPRESSION, uint16(ApplicationSettings::getInstance().getTiffBwCompression()));
+   }


### PR DESCRIPTION
This is a patch I submitted upstream https://github.com/4lex4/scantailor-advanced/pull/166 a while ago, but upstream is unresponsive.

It doesn't apply on the EA branch (for beta), but I can port it there. (see #4)

This cause some images to not be generated as indexed colours isn't supported with JPEG, so in that case the patch reverts to LZW compression.