### PR TITLE
update deprecated boost url

### DIFF
--- a/com.github._4lex4.ScanTailor-Advanced.yaml
+++ b/com.github._4lex4.ScanTailor-Advanced.yaml
@@ -23,7 +23,7 @@ modules:
   - name: boost
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.bz2
+        url: https://archives.boost.io/release/1.68.0/source/boost_1_68_0.tar.bz2
         sha256: 7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
     buildsystem: simple
     build-commands:


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
